### PR TITLE
Conforming version number to standards.

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Doki Theme for Firefox",
   "short_name": "Doki Theme",
-  "version": "74.1-2.0.0",
+  "version": "74.2.0",
   "description": "A collection of themes based on girls from various anime, manga, and visual novels series.",
   "manifest_version": 2,
   "icons": {


### PR DESCRIPTION
## Motivation

The add-on linter doesn't like `v74.1-2.0.0`, [see issue](https://github.com/mozilla/addons-linter/issues/1905), so opted for v74.2.0 for now.