### PR TITLE
Device Match Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+# 78.0-2.1.1 [Device Match Fix]
+
+- Restored `Device Match` functionality for Firefox v100+.
+
 # 78.0-2.1.0 [React Update]
 
 - Non-Functional update. Updated React to v18.

--- a/buildSrc/src/BuildThemes.ts
+++ b/buildSrc/src/BuildThemes.ts
@@ -74,6 +74,7 @@ function buildFireFoxTheme(
   );
   const colorsOverride = dokiThemeChromeDefinition.overrides.theme &&
     dokiThemeChromeDefinition.overrides.theme.colors || {};
+  const colorScheme = dokiThemeDefinition.dark ? "dark" : "light";
   return {
     ...manifestTemplate,
     colors: replaceValues(
@@ -82,7 +83,11 @@ function buildFireFoxTheme(
         colorsOverride[key] || color,
         namedColors
       ))
-    )
+    ),
+    properties: {
+      color_scheme: colorScheme,
+      content_color_scheme: colorScheme,
+    }
   };
 }
 

--- a/buildSrc/src/types.ts
+++ b/buildSrc/src/types.ts
@@ -19,5 +19,9 @@ export interface FireFoxTheme {
     "tab_background_text": string,
     "tab_text": string,
     "toolbar": string,
+  },
+  properties: {
+    color_scheme: string;
+    content_color_scheme: string,
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1986,7 +1986,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "neo-async": {
@@ -2024,7 +2024,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -2105,7 +2105,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-key": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1051,7 +1051,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "convert-source-map": {
@@ -1487,7 +1487,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fastest-levenshtein": {
@@ -1571,7 +1571,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "function-bind": {
@@ -1717,13 +1717,13 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -1842,7 +1842,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "kind-of": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Doki Theme for Firefox",
   "short_name": "Doki Theme",
-  "version": "78.2.2",
+  "version": "78.2.3",
   "description": "Cute anime character themes for Firefox.",
   "manifest_version": 2,
   "icons": {

--- a/src/background/deviceThemeManager.ts
+++ b/src/background/deviceThemeManager.ts
@@ -6,6 +6,7 @@ import {
 } from "../Events";
 import { pluginSettings } from "../Storage";
 import { SingleThemeManager, ThemeStuff } from "./singleThemeManager";
+import { DokiTheme } from "../common/DokiTheme";
 
 const mediaQuery = "(prefers-color-scheme: dark)";
 
@@ -109,6 +110,18 @@ export class DeviceThemeManager extends SingleThemeManager {
 
   public static isDark() {
     return window.matchMedia(mediaQuery).matches;
+  }
+
+  protected decorateTheme(dokiTheme: DokiTheme): browser._manifest.ThemeType {
+    const decoratedTheme = super.decorateTheme(dokiTheme);
+    return {
+      ...decoratedTheme,
+      properties: {
+        ...decoratedTheme.properties,
+        color_scheme: "system",
+        content_color_scheme: "system",
+      },
+    };
   }
 
   private mediaChangeListener = this.handleMediaChange.bind(this);

--- a/src/background/themeManager.ts
+++ b/src/background/themeManager.ts
@@ -7,6 +7,7 @@ import {
   PluginEventTypes,
   ThemeSetEventPayload,
 } from "../Events";
+import ThemeType = browser._manifest.ThemeType;
 
 export abstract class ThemeManager {
   abstract handleMessage(message: any): Promise<void>;
@@ -58,9 +59,13 @@ export abstract class ThemeManager {
 
   async applyBrowserTheme(dokiTheme: DokiTheme) {
     themeExtensionIconInToolBar(dokiTheme);
-    browser.theme.update(dokiTheme.browserTheme);
+    browser.theme.update(this.decorateTheme(dokiTheme));
     await pluginSettings.set({ currentTheme: dokiTheme.themeId });
     await this.dispatchCurrentThemeSet(dokiTheme);
+  }
+
+  protected decorateTheme(dokiTheme: DokiTheme): ThemeType {
+    return dokiTheme.browserTheme;
   }
 
   private async dispatchCurrentThemeSet(dokiTheme: DokiTheme) {

--- a/src/common/DokiThemeProvider.tsx
+++ b/src/common/DokiThemeProvider.tsx
@@ -1,4 +1,10 @@
-import React, {FC, PropsWithChildren, useEffect, useMemo, useState} from "react";
+import React, {
+  FC,
+  PropsWithChildren,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   ContentType,
   DEFAULT_DOKI_THEME,
@@ -49,7 +55,7 @@ export const ThemeContext = React.createContext<DokiThemeContext>({
 });
 
 interface Props {
-  nothing?: string
+  nothing?: string;
 }
 
 const DokiThemeProvider: FC<PropsWithChildren<Props>> = ({ children }) => {

--- a/src/common/DokiThemeProvider.tsx
+++ b/src/common/DokiThemeProvider.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from "react";
+import React, {FC, PropsWithChildren, useEffect, useMemo, useState} from "react";
 import {
   ContentType,
   DEFAULT_DOKI_THEME,
@@ -48,7 +48,11 @@ export const ThemeContext = React.createContext<DokiThemeContext>({
   isInitialized: false,
 });
 
-const DokiThemeProvider: FC = ({ children }) => {
+interface Props {
+  nothing?: string
+}
+
+const DokiThemeProvider: FC<PropsWithChildren<Props>> = ({ children }) => {
   const [themeId, setThemeId] = useState<string>(DEFAULT_DARK_THEME_ID);
   const [currentContent, setCurrentContent] = useState<ContentType>(
     ContentType.PRIMARY

--- a/src/common/DokiThemeProviderContentScript.tsx
+++ b/src/common/DokiThemeProviderContentScript.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from "react";
+import React, {FC, PropsWithChildren, useEffect, useMemo, useState} from "react";
 import {
   ContentType,
   DEFAULT_DOKI_THEME,
@@ -16,7 +16,11 @@ export const ThemeContextContentScript = React.createContext<DokiThemeContext>({
   isInitialized: false,
 });
 
-const DokiThemeProviderContentScript: FC = ({ children }) => {
+interface Props {
+  nothing?: string
+}
+
+const DokiThemeProviderContentScript: FC<PropsWithChildren<Props>> = ({ children }) => {
   const [themeId, setThemeId] = useState<string>(DEFAULT_DARK_THEME_ID);
   const [initialized, setInitialized] = useState<boolean>(false);
   const [currentContent, setCurrentContent] = useState<ContentType>(

--- a/src/common/DokiThemeProviderContentScript.tsx
+++ b/src/common/DokiThemeProviderContentScript.tsx
@@ -1,4 +1,10 @@
-import React, {FC, PropsWithChildren, useEffect, useMemo, useState} from "react";
+import React, {
+  FC,
+  PropsWithChildren,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   ContentType,
   DEFAULT_DOKI_THEME,
@@ -17,10 +23,12 @@ export const ThemeContextContentScript = React.createContext<DokiThemeContext>({
 });
 
 interface Props {
-  nothing?: string
+  nothing?: string;
 }
 
-const DokiThemeProviderContentScript: FC<PropsWithChildren<Props>> = ({ children }) => {
+const DokiThemeProviderContentScript: FC<PropsWithChildren<Props>> = ({
+  children,
+}) => {
   const [themeId, setThemeId] = useState<string>(DEFAULT_DARK_THEME_ID);
   const [initialized, setInitialized] = useState<boolean>(false);
   const [currentContent, setCurrentContent] = useState<ContentType>(

--- a/src/common/FeatureProvider.tsx
+++ b/src/common/FeatureProvider.tsx
@@ -1,4 +1,10 @@
-import React, {FC, PropsWithChildren, useEffect, useMemo, useState} from "react";
+import React, {
+  FC,
+  PropsWithChildren,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { pluginSettings } from "../Storage";
 import {
   FeatureSetEventPayload,
@@ -32,7 +38,7 @@ export const FeatureContext = React.createContext<PluginFeatureContext>({
 });
 
 interface Props {
-  nothing?: string
+  nothing?: string;
 }
 
 const FeatureProvider: FC<PropsWithChildren<Props>> = ({ children }) => {

--- a/src/common/FeatureProvider.tsx
+++ b/src/common/FeatureProvider.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from "react";
+import React, {FC, PropsWithChildren, useEffect, useMemo, useState} from "react";
 import { pluginSettings } from "../Storage";
 import {
   FeatureSetEventPayload,
@@ -31,7 +31,11 @@ export const FeatureContext = React.createContext<PluginFeatureContext>({
   features: defaultFeatures,
 });
 
-const FeatureProvider: FC = ({ children }) => {
+interface Props {
+  nothing?: string
+}
+
+const FeatureProvider: FC<PropsWithChildren<Props>> = ({ children }) => {
   const [initialized, setInitialized] = useState<boolean>(false);
   const [features, setFeatures] = useState<PluginFeatures>(defaultFeatures);
   const setTheme = (context: PluginFeatures) => {

--- a/src/common/FeatureProviderContentScript.tsx
+++ b/src/common/FeatureProviderContentScript.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from "react";
+import React, {FC, PropsWithChildren, useEffect, useMemo, useState} from "react";
 import { pluginSettings } from "../Storage";
 import { FeatureSetEventPayload, PluginEventTypes } from "../Events";
 
@@ -24,7 +24,11 @@ export const FeatureContextContentScript =
     features: defaultFeatures,
   });
 
-const FeatureProvider: FC = ({ children }) => {
+interface Props {
+  nothing?: string
+}
+
+const FeatureProvider: FC<PropsWithChildren<Props>> = ({ children }) => {
   const [initialized, setInitialized] = useState<boolean>(false);
   const [features, setFeatures] = useState<PluginFeatures>(defaultFeatures);
   const setTheme = (context: PluginFeatures) => {

--- a/src/common/FeatureProviderContentScript.tsx
+++ b/src/common/FeatureProviderContentScript.tsx
@@ -1,4 +1,10 @@
-import React, {FC, PropsWithChildren, useEffect, useMemo, useState} from "react";
+import React, {
+  FC,
+  PropsWithChildren,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { pluginSettings } from "../Storage";
 import { FeatureSetEventPayload, PluginEventTypes } from "../Events";
 
@@ -25,7 +31,7 @@ export const FeatureContextContentScript =
   });
 
 interface Props {
-  nothing?: string
+  nothing?: string;
 }
 
 const FeatureProvider: FC<PropsWithChildren<Props>> = ({ children }) => {

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -1,0 +1,8 @@
+declare namespace browser._manifest {
+  interface ThemeType {
+    properties: {
+      color_scheme: "system";
+      content_color_scheme: "system";
+    };
+  }
+}


### PR DESCRIPTION
## Changes

- Restored `Device Match` functionality for Firefox v100+.

## Motivation

Closes #93 

## Context

Since Firefox 100 [theme properties](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#properties) now has `color_scheme` & `content_color_scheme` which are set to auto by default. It must be set to `system` in order for media queries to work again....